### PR TITLE
Prevent proposal canceler actions from being bundled into multi-action proposals

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   FOUNDRY_PROFILE: ci
-  MAINNET_URL: https://ethereum-rpc.publicnode.com
+  MAINNET_URL: ${{ secrets.MAINNET_URL }}
 
 jobs:
   check:

--- a/src/interfaces/IVoter.sol
+++ b/src/interfaces/IVoter.sol
@@ -45,6 +45,7 @@ interface IVoter {
     function EXECUTION_DEADLINE() external view returns (uint256);
     function MIN_TIME_BETWEEN_PROPOSALS() external view returns (uint256);
     function MAX_PCT() external view returns (uint256);
+    function MAX_DESCRIPTION_BYTES() external view returns (uint256);
     
     function staker() external view returns (address);
     function minCreateProposalPct() external view returns (uint256);
@@ -57,6 +58,7 @@ interface IVoter {
     function minCreateProposalWeight() external view returns (uint256);
     
     function getProposalData(uint256 id) external view returns (
+        string memory description,
         uint256 epoch,
         uint256 createdAt,
         uint256 quorumWeight,
@@ -66,6 +68,8 @@ interface IVoter {
         bool executable,
         Action[] memory payload
     );
+    function proposalPayload(uint256 id) external view returns (Action[] memory);
+    function proposalDescription(uint256 id) external view returns (string memory);
     
     function createNewProposal(address account, Action[] calldata payload) external returns (uint256);
     function voteForProposal(address account, uint256 id) external;

--- a/test/dao/Voter.t.sol
+++ b/test/dao/Voter.t.sol
@@ -193,11 +193,9 @@ contract VoterTest is Setup {
         voter.cancelProposal(propId);
     }
 
-    function test_CannotCancelProposalWithCancelerPayloadAsNonFirstAction() public {
-        uint256 propId = createProposalDataWithCancelerAsNonFirstAction();
-        vm.prank(address(core));
-        vm.expectRevert("Contains canceler payload");
-        voter.cancelProposal(propId);
+    function test_CannotCreateMultiActionProposalWithCanceler() public {
+        vm.expectRevert("Payload length not 1");
+        createProposalDataWithCancelerAsNonFirstAction();
     }
 
     function test_CannotCancelProposalWithCancelerPayloadAndTargetIsZeroAddress() public {


### PR DESCRIPTION
prevent proposers from adding a canceler action as a way to bypass guardian.