### PR TITLE
fix: apply off-peg boost to minimum rate in ir calc

### DIFF
--- a/script/actions/DeploySreUsd.s.sol
+++ b/script/actions/DeploySreUsd.s.sol
@@ -106,7 +106,7 @@ contract DeploySreUsd is TenderlyHelper, CreateXHelper, BaseAction {
         salt = CreateX.SALT_INTEREST_RATE_CALCULATOR_V2;
         constructorArgs = abi.encode(
             "V2", // Suffix
-            2e16 / uint256(365 days), //2% apr min rate
+            2e16 / uint256(365 days) * 2, //4% - we multiply by 2 to adjust for rate ratio base
             5e17, // Rate ratio base
             1e17, // Rate ratio additional
             address(Protocol.PRICE_WATCHER) // price watcher

--- a/test/e2e/Setup.sol
+++ b/test/e2e/Setup.sol
@@ -370,7 +370,7 @@ contract Setup is Test {
         priceWatcher = new PriceWatcher(address(registry));
         rateCalculator = new InterestRateCalculatorV2(
             "V2", //suffix
-            2e16 / uint256(365 days), //2%
+            2e16 / uint256(365 days) * 2, //4% - we multiply by 2 to adjust for rate ratio base
             5e17, //rate ratio base
             1e17, //rate ratio additional
             address(priceWatcher) //price watcher

--- a/test/integration/PriceWatcher.t.sol
+++ b/test/integration/PriceWatcher.t.sol
@@ -28,7 +28,7 @@ contract PriceWatcherTest is Setup {
         UPDATE_INTERVAL = priceWatcher.UPDATE_INTERVAL();
         interestRateCalculator = new InterestRateCalculatorV2(
             "V2",
-            2e16 / uint256(365 days),//2%
+            2e16 / uint256(365 days) * 2,//4% - we multiply by 2 to adjust for rate ratio base
             5e17,
             1e17,
             address(priceWatcher)

--- a/test/integration/sreUSD.t.sol
+++ b/test/integration/sreUSD.t.sol
@@ -93,7 +93,7 @@ contract SreUSDTest is Setup {
         //new interest calculator
         InterestRateCalculatorV2 calcv2 = new InterestRateCalculatorV2(
             "V2",
-            2e16 / uint256(365 days),//2%
+            2e16 / uint256(365 days) * 2,//4% - we multiply by 2 to adjust for rate ratio base
             5e17,
             1e17,
             address(priceWatcher)


### PR DESCRIPTION
IR calculator selects a rate based on the higher of 3 different values at the time of calculation:
1. half underlying rate
2. half risk free rate
3. minimum rate

in the even that 3 is the highest, `rateRatio` was not applied to the calculation. with the introduction of the off-peg boost, this creates a problem when fees are distributed in a later epoch. Namely, the Fee Deposit Controller "reverse-engineers" the fee boost calculation in a manner that assumes the `rateRatio` was applied during all IR calculations regardless of which of the 3 values above was the highest. Since it does not have any way of accounting for discrete scenarios when `minimumRate` was selected, the outcome will be incorrect if ever it was the highest through the course of a given epoch.